### PR TITLE
Add option for running commands as root

### DIFF
--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -212,7 +212,7 @@ int     stop_child(CmdInfo& ci, int transId, const TimeVal& now, bool notify = t
 void    erase_child(MapChildrenT::iterator& it);
 
 int     process_command();
-void    initialize(int userid, bool use_alt_fds);
+void    initialize(int userid, bool use_alt_fds, bool run_as_root);
 int     finalize();
 int     set_nonblock_flag(pid_t pid, int fd, bool value);
 int     erl_exec_kill(pid_t pid, int signal);
@@ -545,9 +545,10 @@ int set_nice(pid_t pid,int nice, std::string& error)
 void usage(char* progname) {
     fprintf(stderr,
         "Usage:\n"
-        "   %s [-n] [-alarm N] [-debug [Level]] [-user User]\n"
+        "   %s [-n] [-root] [-alarm N] [-debug [Level]] [-user User]\n"
         "Options:\n"
         "   -n              - Use marshaling file descriptors 3&4 instead of default 0&1.\n"
+        "   -root           - Allow running as root.\n"
         "   -alarm N        - Allow up to <N> seconds to live after receiving SIGTERM/SIGINT (default %d)\n"
         "   -debug [Level]  - Turn on debug mode (default Level: 1)\n"
         "   -user User      - If started by root, run as User\n"
@@ -569,6 +570,7 @@ int main(int argc, char* argv[])
     struct sigaction sact, sterm;
     int userid = 0;
     bool use_alt_fds = false;
+    bool run_as_root = false;
 
     sterm.sa_handler = gotsignal;
     sigemptyset(&sterm.sa_mask);
@@ -611,11 +613,13 @@ int main(int argc, char* argv[])
                     exit(3);
                 }
                 userid = pw->pw_uid;
+            } else if (strcmp(argv[res], "-root") == 0) {
+                run_as_root = true;
             }
         }
     }
 
-    initialize(userid, use_alt_fds);
+    initialize(userid, use_alt_fds, run_as_root);
 
     while (!terminated) {
 
@@ -858,11 +862,12 @@ int process_command()
     return 0;
 }
 
-void initialize(int userid, bool use_alt_fds)
+void initialize(int userid, bool use_alt_fds, bool run_as_root)
 {
     // If we are root, switch to non-root user and set capabilities
     // to be able to adjust niceness and run commands as other users.
-    if (getuid() == 0) {
+    // unless run_as_root is set
+    if (getuid() == 0 && !run_as_root) {
         if (userid == 0) {
             fprintf(stderr, "When running as root, \"-user User\" option must be provided!\r\n");
             exit(4);


### PR DESCRIPTION
Add (in C-land) -root option to allow running as root regardless of erlexec's opinions on the matter
Add the root flag, and correctly pass it through to, erlang-land
